### PR TITLE
Fix Submission.Builer#completeStep to replace the last entry

### DIFF
--- a/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/model/Submission.java
+++ b/src/main/java/uk/ac/cam/cl/dtg/teaching/pottery/model/Submission.java
@@ -165,6 +165,7 @@ public class Submission {
       if (!isComplete(status)) {
         throw new IllegalArgumentException();
       }
+      this.steps.removeLast();
       this.steps.offerLast(new StepResult(name, status, msec, output));
       return this;
     }


### PR DESCRIPTION
I made a boo-boo in switching to the ArrayDeque so it was adding new entries instead of updating them. This fixes that.